### PR TITLE
hover effect on grid icon disabled

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import './Assets/Styles/App.scss';
 import BaseLayer from './Components/Layers/BaseLayer';
 import OverviewLayer from './Components/Layers/OverviewLayer';
@@ -12,10 +12,11 @@ function App() {
   const [gridOpened, setGridOpened] = useState()
   const identity = a => a;
 
-  const toggleMenu = () => setMenuOpened(!menuOpened)
+  const toggleMenu = () => setMenuOpened(menuOpened => !menuOpened)
 
-  const setGridButtonHoveredTrue = () => setGridButtonHovered(true)
-  const setGridButtonHoveredFalse = () => setGridButtonHovered(false)
+  const toggleGrid = () => setGridOpened(gridOpened => !gridOpened)
+
+  const toggleGridHover = () => setGridButtonHovered(gridButtonHovered => !gridButtonHovered)
 
   const safeToggleOperation = (operation, guard, recover = () => {}) => 
   input => guard(input, operation) || recover;
@@ -27,8 +28,6 @@ function App() {
 
   const orElse = identity;
 
-  const toggleGrid = () => setGridOpened(gridOpened => !gridOpened)
-
   const safeToggleGridOnKeyPressed = safeToggleOperation(
     toggleGrid,
     onlyIf(keyPressedIsQ),
@@ -37,7 +36,7 @@ function App() {
 
   return (
     <div tabIndex={0} onKeyDown={safeToggleGridOnKeyPressed}>
-      <GridButtonContext.Provider value={{gridButtonHovered, setGridButtonHoveredTrue, setGridButtonHoveredFalse, toggleGrid}}>
+      <GridButtonContext.Provider value={{gridButtonHovered, toggleGridHover, toggleGrid}}>
       <MenuContext.Provider value={{toggleMenu}}>
         <BaseLayer />
       </MenuContext.Provider>

--- a/src/Assets/Styles/components/menu/home_menu_overlay.scss
+++ b/src/Assets/Styles/components/menu/home_menu_overlay.scss
@@ -6,7 +6,7 @@
     position: fixed;
     padding: 12px 0 12px 1rem;
     background-color: $bkg-menu-overlay;
-    @include flex(row, center, start, 0.5em)
+    @include flex(row, center, flex-start, 0.5em)
 }
 
 .button-container {

--- a/src/Components/Home/MenuOverlay.js
+++ b/src/Components/Home/MenuOverlay.js
@@ -6,7 +6,7 @@ import { MenuButtonsContext, MenuContext } from '../../Context/MenuContext'
 function MenuOverlay() {
 
     const {toggleMenu} = useContext(MenuContext)
-    const {gridButtonHovered, setGridButtonHoveredTrue, setGridButtonHoveredFalse, toggleGrid} = useContext(GridButtonContext)
+    const {gridButtonHovered, toggleGrid} = useContext(GridButtonContext)
     const {HamburgerIcon, GridIcon, ArrowLeftIcon, mediumIconSize, bigIconSize} = useContext(MenuButtonsContext)
     const [quickMenuButtonClasses, setQuickMenuButtonClasses] = useState("grid-button-container");
     const [arrowIconClasses, setArrowIconClasses] = useState("arrow-left")
@@ -35,9 +35,7 @@ function MenuOverlay() {
         </div>
         <div className={quickMenuButtonClasses}>
           <GridIcon size={mediumIconSize}
-                    onClick={toggleGrid}
-                    onMouseEnter={setGridButtonHoveredTrue}
-                    onMouseLeave={setGridButtonHoveredFalse} />
+                    onClick={toggleGrid} />
         </div>
         <ArrowLeftIcon size={bigIconSize} className={arrowIconClasses} />
     </div>

--- a/src/Components/Home/Title.js
+++ b/src/Components/Home/Title.js
@@ -4,7 +4,7 @@ import { GridButtonContext } from '../../Context/GridButtonContext'
 
 function Title() {
 
-  const {gridButtonHovered, setGridButtonHoveredTrue, setGridButtonHoveredFalse, toggleGrid} = useContext(GridButtonContext)
+  const {gridButtonHovered, toggleGridHover, toggleGrid} = useContext(GridButtonContext)
   const [titleBtnClasses, setTitleBtnClasses] = useState("title-btn")
 
   useEffect(() => {
@@ -19,8 +19,8 @@ function Title() {
       <div className="title-support">press 'q' for quick navigation</div>
       <button className={titleBtnClasses}
               onClick={toggleGrid}
-              onMouseEnter={setGridButtonHoveredTrue}
-              onMouseLeave={setGridButtonHoveredFalse}
+              onMouseEnter={toggleGridHover}
+              onMouseLeave={toggleGridHover}
       >q</button>
     </div>
   )

--- a/src/Context/GridButtonContext.js
+++ b/src/Context/GridButtonContext.js
@@ -3,8 +3,7 @@ import { createContext } from "react";
 export const GridButtonContext = createContext(
     {
         gridButtonHovered: false,
-        setGridButtonHoveredTrue: () => {},
-        setGridButtonHoveredFalse: () => {},
+        toggleGridHover: () => {},
         toggleGrid: () => {}
     }
 )


### PR DESCRIPTION
the hover effect on the button in the title still remains. The effect is disabled only if hovering the grid icon in the menu overlay